### PR TITLE
Include more metadata for error responses

### DIFF
--- a/public/buttons.html
+++ b/public/buttons.html
@@ -35,6 +35,7 @@
                 body: JSON.stringify({
                   cart: [
                     {
+                      // change this to "PRODUCT_789" to force an error
                       sku: "PRODUCT_123",
                       quantity: 2,
                     },

--- a/src/controller/config-controller.ts
+++ b/src/controller/config-controller.ts
@@ -5,7 +5,7 @@ const {
   paypal: { clientID, webBaseUrl },
 } = config;
 
-export async function clientIDController(fastify: FastifyInstance) {
+export async function configController(fastify: FastifyInstance) {
   fastify.get(
     "/client-config",
     function (_request: FastifyRequest, reply: FastifyReply) {

--- a/src/controller/error-controller.ts
+++ b/src/controller/error-controller.ts
@@ -1,0 +1,20 @@
+import type { FastifyInstance, FastifyError } from "fastify";
+
+type HttpErrorResponse = {
+  statusCode: number;
+  details?: Record<string, string>;
+} & FastifyError;
+
+export function setErrorHandler(fastify: FastifyInstance) {
+  fastify.setErrorHandler(function (error, request, reply) {
+    this.log.error(error);
+
+    const errorResponse = {
+      ...error,
+      message: error.message,
+      statusCode: error.statusCode || 500,
+    } as HttpErrorResponse;
+
+    reply.status(errorResponse.statusCode).send({ ...errorResponse });
+  });
+}

--- a/src/data/products.json
+++ b/src/data/products.json
@@ -8,5 +8,10 @@
     "name": "product 2",
     "price": "100",
     "status": "IN_STOCK"
+  },
+  "PRODUCT_789": {
+    "name": "product 3",
+    "price": "-100",
+    "status": "INVALID"
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,10 +1,10 @@
 import type { FastifyInstance } from "fastify";
 import { clientTokenController } from "./controller/client-token-controller";
 import { createOrderController } from "./controller/order-controller";
-import { clientIDController } from "./controller/config-controller";
+import { configController } from "./controller/config-controller";
 
 export default async function router(fastify: FastifyInstance) {
   fastify.register(clientTokenController, { prefix: "/api/paypal" });
   fastify.register(createOrderController, { prefix: "/api/paypal" });
-  fastify.register(clientIDController, { prefix: "/api/paypal" });
+  fastify.register(configController, { prefix: "/api/paypal" });
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,8 +2,10 @@ import type { FastifyInstance } from "fastify";
 import { clientTokenController } from "./controller/client-token-controller";
 import { createOrderController } from "./controller/order-controller";
 import { configController } from "./controller/config-controller";
+import { setErrorHandler } from "./controller/error-controller";
 
 export default async function router(fastify: FastifyInstance) {
+  setErrorHandler(fastify);
   fastify.register(clientTokenController, { prefix: "/api/paypal" });
   fastify.register(createOrderController, { prefix: "/api/paypal" });
   fastify.register(configController, { prefix: "/api/paypal" });


### PR DESCRIPTION
The main change in this PR is to improve the JSON response for errors. For example, if the fetch() call fails in the createOrder() callback, the following response will be returned:

<img width="1563" alt="Screen Shot 2023-02-09 at 9 55 40 AM" src="https://user-images.githubusercontent.com/534034/217866228-44dc32ae-6e90-4e3b-ad3a-30ed5c393039.png">
