### PR TITLE
chore: add basic functionality for order capture

### DIFF
--- a/public/buttons.html
+++ b/public/buttons.html
@@ -45,6 +45,17 @@
                 .then((response) => response.json())
                 .then((order) => order.id);
             },
+            onApprove(data) {
+              return fetch("/api/paypal/capture-order", {
+                method: "post",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ orderID: data.orderID }),
+              })
+                .then((response) => response.json())
+                .then((data) => console.log(data));
+            },
           })
           .render("#paypal-buttons-container")
           .catch((error) => {

--- a/src/controller/order-controller.ts
+++ b/src/controller/order-controller.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 
 import getAuthToken from "../auth/get-auth-token";
 import createOrder from "../order/create-order";
+import captureOrder from "../order/capture-order";
 import products from "../data/products.json";
 
 import type { CreateOrderRequestBody } from "@paypal/paypal-js";
@@ -67,6 +68,17 @@ async function createOrderHandler(
   reply.send(data);
 }
 
+async function captureOrderHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { orderID } = request.body as { orderID: string };
+  const { access_token: accessToken } = await getAuthToken();
+
+  const data = await captureOrder(accessToken, orderID);
+  reply.send(data);
+}
+
 export async function createOrderController(fastify: FastifyInstance) {
   fastify.route({
     method: "POST",
@@ -87,6 +99,25 @@ export async function createOrderController(fastify: FastifyInstance) {
                 quantity: { type: "number" },
               },
             },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function captureOrderController(fastify: FastifyInstance) {
+  fastify.route({
+    method: "POST",
+    url: "/capture-order",
+    handler: captureOrderHandler,
+    schema: {
+      body: {
+        type: "object",
+        required: ["orderID"],
+        properties: {
+          orderID: {
+            type: "string",
           },
         },
       },

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import { clientTokenController } from "./controller/client-token-controller";
-import { createOrderController } from "./controller/order-controller";
+import {
+  createOrderController,
+  captureOrderController,
+} from "./controller/order-controller";
 import { configController } from "./controller/config-controller";
 import { setErrorHandler } from "./controller/error-controller";
 
@@ -8,5 +11,6 @@ export default async function router(fastify: FastifyInstance) {
   setErrorHandler(fastify);
   fastify.register(clientTokenController, { prefix: "/api/paypal" });
   fastify.register(createOrderController, { prefix: "/api/paypal" });
+  fastify.register(captureOrderController, { prefix: "/api/paypal" });
   fastify.register(configController, { prefix: "/api/paypal" });
 }


### PR DESCRIPTION
This PR adds functionality for `onApprove()`. The new order capture endpoint includes the same error handling functionality as the create order endpoint.

# Screenshots

## Successful capture
<img width="1597" alt="Screen Shot 2023-02-09 at 2 37 17 PM" src="https://user-images.githubusercontent.com/534034/217934402-07114d86-29ea-4ef5-b48f-d66e4f36c2bd.png">


## Failed capture with an invalid OrderID
<img width="1382" alt="Screen Shot 2023-02-09 at 2 36 29 PM" src="https://user-images.githubusercontent.com/534034/217934368-e932c29d-23b5-4b1f-a31e-952ec533084f.png">

