### PR TITLE
chore: pass more info about items when creating order

### DIFF
--- a/public/buttons.html
+++ b/public/buttons.html
@@ -35,10 +35,18 @@
                 body: JSON.stringify({
                   cart: [
                     {
-                      // change this to "PRODUCT_789" to force an error
-                      sku: "PRODUCT_123",
+                      sku: "1blwyeo8",
                       quantity: 2,
                     },
+                    {
+                      sku: "i5b1g92y",
+                      quantity: 1,
+                    },
+                    // uncomment this to force an error
+                    // {
+                    //   sku: "xyw5kd7k",
+                    //   quantity: 1,
+                    // },
                   ],
                 }),
               })

--- a/src/controller/order-controller.ts
+++ b/src/controller/order-controller.ts
@@ -5,7 +5,7 @@ import createOrder from "../order/create-order";
 import captureOrder from "../order/capture-order";
 import products from "../data/products.json";
 
-import type { CreateOrderRequestBody } from "@paypal/paypal-js";
+import type { CreateOrderRequestBody, PurchaseItem } from "@paypal/paypal-js";
 
 type CartItem = {
   sku: keyof typeof products;
@@ -49,16 +49,18 @@ async function createOrderHandler(
           },
         },
         items: cart.map(({ sku, quantity }) => {
-          const { name, price } = products[sku];
+          const { name, description, price, category } = products[sku];
           return {
             name,
             sku,
+            description,
+            category: category,
             quantity: quantity.toString(),
             unit_amount: {
               currency_code: "USD",
               value: price,
             },
-          };
+          } as PurchaseItem;
         }),
       },
     ],

--- a/src/data/products.json
+++ b/src/data/products.json
@@ -1,17 +1,29 @@
 {
-  "PRODUCT_123": {
-    "name": "product 1",
+  "1blwyeo8": {
+    "sku": "1blwyeo8",
+    "name": "Potted Plant",
+    "description": "A leafy green plant in pot.",
     "price": "50.75",
-    "status": "IN_STOCK"
+    "category": "PHYSICAL_GOODS",
+    "status": "IN_STOCK",
+    "image": "🪴"
   },
-  "PRODUCT_456": {
-    "name": "product 2",
-    "price": "100",
-    "status": "IN_STOCK"
+  "i5b1g92y": {
+    "sku": "i5b1g92y",
+    "name": "Seedling",
+    "description": "A seedling, or a young plant, as a newly sprouted tree.",
+    "price": "25.20",
+    "category": "PHYSICAL_GOODS",
+    "status": "IN_STOCK",
+    "image": "🌱"
   },
-  "PRODUCT_789": {
-    "name": "product 3",
+  "xyw5kd7k": {
+    "sku": "xyw5kd7k",
+    "name": "Cactus",
+    "description": "A cactus, a spiky plant that grows in very dry regions.",
     "price": "-100",
-    "status": "INVALID"
+    "category": "PHYSICAL_GOODS",
+    "status": "INVALID",
+    "image": "🌵"
   }
 }


### PR DESCRIPTION
Pass more information about items when creating an order. This info shows to the buyer on the member checkout page:

<img width="902" alt="Screen Shot 2023-02-14 at 12 28 55 PM" src="https://user-images.githubusercontent.com/534034/218827521-47db0821-b80c-41ef-839e-26fc872a95ed.png">
