### PR TITLE
Add onError callback

### DIFF
--- a/public/buttons.html
+++ b/public/buttons.html
@@ -51,7 +51,19 @@
                 }),
               })
                 .then((response) => response.json())
-                .then((order) => order.id);
+                .then((orderResponse) => {
+                  if (orderResponse.id === undefined) {
+                    // throw an error if orderID is missing
+                    throw new Error(orderResponse.message);
+                  }
+
+                  return orderResponse.id;
+                })
+                .catch((error) => {
+                  throw new Error(
+                    `createOrder callback failed - ${error.message}`
+                  );
+                });
             },
             onApprove(data) {
               return fetch("/api/paypal/capture-order", {
@@ -63,6 +75,12 @@
               })
                 .then((response) => response.json())
                 .then((data) => console.log(data));
+            },
+            onError(error) {
+              console.error({
+                callback: "onError",
+                errorObject: error,
+              });
             },
           })
           .render("#paypal-buttons-container")

--- a/src/auth/cache.ts
+++ b/src/auth/cache.ts
@@ -34,7 +34,7 @@ export default class Cache {
       return originalValue;
     } else {
       logger.debug("key is expired");
-      // TODO: delete from cache
+      this.store.delete(credentials);
     }
   }
 


### PR DESCRIPTION
This PR adds the `onError()` callback. It also updates the `createOrder()` callback to throw an error when the orderID is missing from the response. 

Here's a screenshot of what the `onError()` callback will print when there's a failure with creating the order:
<img width="1510" alt="Screen Shot 2023-02-14 at 8 11 14 PM" src="https://user-images.githubusercontent.com/534034/218909872-e017314f-44be-42a0-9d06-9688b4dcba2e.png">

