### PR TITLE
Improve error handling in onApprove callback

### DIFF
--- a/public/buttons.html
+++ b/public/buttons.html
@@ -51,13 +51,13 @@
                 }),
               })
                 .then((response) => response.json())
-                .then((orderResponse) => {
-                  if (orderResponse.id === undefined) {
+                .then((orderData) => {
+                  if (orderData.id === undefined) {
                     // throw an error if orderID is missing
-                    throw new Error(orderResponse.message);
+                    throw new Error(orderData.message);
                   }
 
-                  return orderResponse.id;
+                  return orderData.id;
                 })
                 .catch((error) => {
                   throw new Error(
@@ -65,7 +65,7 @@
                   );
                 });
             },
-            onApprove(data) {
+            onApprove(data, actions) {
               return fetch("/api/paypal/capture-order", {
                 method: "post",
                 headers: {
@@ -74,7 +74,39 @@
                 body: JSON.stringify({ orderID: data.orderID }),
               })
                 .then((response) => response.json())
-                .then((data) => console.log(data));
+                .then((orderData) => {
+                  // Three cases to handle:
+                  //   (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
+                  //   (2) Other non-recoverable errors -> Show a failure message
+                  //   (3) Successful transaction -> Show confirmation or thank you
+
+                  const errorDetail =
+                    Array.isArray(orderData.details) && orderData.details[0];
+
+                  if (
+                    errorDetail &&
+                    errorDetail.issue === "INSTRUMENT_DECLINED"
+                  ) {
+                    // recoverable state
+                    // https://developer.paypal.com/docs/checkout/standard/customize/handle-funding-failures/
+                    return actions.restart();
+                  }
+
+                  // non-recoverable state
+                  if (errorDetail) {
+                    return console.error({
+                      callback: "onApprove",
+                      errorDetail: orderData,
+                    });
+                  }
+
+                  // successful capture
+                  console.log(
+                    "Capture result",
+                    orderData,
+                    JSON.stringify(orderData, null, 2)
+                  );
+                });
             },
             onError(error) {
               console.error({

--- a/src/controller/order-controller.ts
+++ b/src/controller/order-controller.ts
@@ -22,7 +22,8 @@ function getTotalAmount(cartItems: CartItem[]): string {
     })
     .reduce((partialSum, a) => partialSum + a, 0);
 
-  return amountValue.toLocaleString("en-US", { minimumFractionDigits: 2 });
+  const roundedAmount = Math.round((amountValue + Number.EPSILON) * 100) / 100;
+  return roundedAmount.toString();
 }
 
 async function createOrderHandler(

--- a/src/order/capture-order.ts
+++ b/src/order/capture-order.ts
@@ -42,6 +42,9 @@ export default async function captureOrder(
           "Content-Type": "application/json",
           Authorization: `Bearer ${accessToken}`,
           "Accept-Language": "en_US",
+          // uncomment this to force an error for negative testing
+          // https://developer.paypal.com/tools/sandbox/negative-testing/request-headers/
+          // "PayPal-Mock-Response": '{"mock_application_codes": "INSTRUMENT_DECLINED"}'
         },
       }
     );


### PR DESCRIPTION
This PR updates the onApprove() callback to handle payment failures and to log errors.

### Successful Payment Screenshot
<img width="1283" alt="Screen Shot 2023-02-15 at 4 00 20 PM" src="https://user-images.githubusercontent.com/534034/219186880-f1163cae-6417-406d-9afb-8cea5b2688c6.png">

### Instrument declined use case
<img width="1775" alt="Screen Shot 2023-02-15 at 4 01 41 PM" src="https://user-images.githubusercontent.com/534034/219187188-2463f73b-057b-40b1-83b2-e55026119777.png">
