### PR TITLE
Deploy to fly.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+fly.toml
+Dockerfile
+.dockerignore
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:bullseye as builder
+
+ARG NODE_VERSION=16.19.1
+
+RUN apt-get update; apt install -y curl python-is-python3 pkg-config build-essential
+RUN curl https://get.volta.sh | bash
+ENV VOLTA_HOME /root/.volta
+ENV PATH /root/.volta/bin:$PATH
+RUN volta install node@${NODE_VERSION}
+
+#######################################################################
+
+RUN mkdir /app
+WORKDIR /app
+
+# NPM will not install any package listed in "devDependencies" when NODE_ENV is set to "production",
+# to install all modules: "npm install --production=false".
+# Ref: https://docs.npmjs.com/cli/v9/commands/npm-install#description
+
+ENV NODE_ENV production
+
+COPY . .
+
+RUN npm install --production=false && npm run build
+FROM debian:bullseye
+
+LABEL fly_launch_runtime="nodejs"
+
+COPY --from=builder /root/.volta /root/.volta
+COPY --from=builder /app /app
+
+WORKDIR /app
+ENV NODE_ENV production
+ENV PATH /root/.volta/bin:$PATH
+
+CMD [ "npm", "run", "start" ]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,39 @@
+# fly.toml file generated for paypal-sdk-server-side-integration on 2023-03-08T15:43:57-06:00
+
+app = "paypal-sdk-server-side-integration"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+  FASTIFY_PORT = "8080"
+  FASTIFY_HOST = "0.0.0.0"
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "tap --ts --no-check-coverage",
     "coverage": "npm test -- --coverage-report=html",
     "build": "rimraf dist && tsc",
-    "prestart": "npm run build",
     "start": "NODE_ENV=production node dist/index.js"
   },
   "keywords": [],

--- a/src/controller/order-controller.ts
+++ b/src/controller/order-controller.ts
@@ -132,8 +132,8 @@ async function createOrderHandler(
   const orderResponse = await createOrder(orderPayload);
 
   if (orderResponse.status === "ok") {
-    request.log.info(orderResponse.data, "order successfully created");
-    // TODO: log error details
+    const { id, status } = orderResponse.data;
+    request.log.info({ id, status }, "order successfully created");
   } else {
     request.log.error(orderResponse.data, "failed to create order");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import app from "./app";
 
 const FASTIFY_PORT = Number(process.env.FASTIFY_PORT) || 3006;
+const FASTIFY_HOST = process.env.FASTIFY_HOST || "localhost";
 
 app.listen({
   port: FASTIFY_PORT,
+  host: FASTIFY_HOST,
 });
 
 console.log(`🚀  Fastify server running on port ${FASTIFY_PORT}`);


### PR DESCRIPTION
This Node.js app has been successfully deployed to [Fly.io](https://fly.io/). It's using the free tier and here's the link:
https://paypal-sdk-server-side-integration.fly.dev/

This PR contains the Dockerfile required for deploying. The clientID and clientSecret are checked in via this secrets feature that fly provides: https://fly.io/docs/reference/secrets/. Other non-sensitive environment variables are defined in the Dockerfile.

One thing that tripped me up is how to best do `npm run build` when deploying to prod. Technically TypeScript and rimraf and other dependencies required for building are considered devDependencies so they don't get installed by default in production. I worked around this by using the `--production=false` flag in the dockerfile like so:

```bash
ENV NODE_ENV production
# hack to support dev dependencies required for building the dist folder
RUN npm install --production=false && npm run build
```

Let me know your thoughts on how to better accomplish this.