### PR TITLE
[DTPPSDK-1184] pass custom headers to order API calls

### DIFF
--- a/docs/update-from-client-side-helpers-to-server-side.md
+++ b/docs/update-from-client-side-helpers-to-server-side.md
@@ -35,7 +35,7 @@ PayPal REST API's follow a common integration approach used by other RESTful API
 
 > **Tip**
 >
->  Checkout the [Get Started guide](https://developer.paypal.com/api/rest/) to for a quick tutorial on PayPal REST integrations.
+> Checkout the [Get Started guide](https://developer.paypal.com/api/rest/) to for a quick tutorial on PayPal REST integrations.
 
 <br/>
 
@@ -94,7 +94,7 @@ To simplify the integration of your e-commerce website with the PayPal v2 Orders
 
 <br/>
 
-***Helpful diagram highlighting the sequence of events required for a client + server integration for creating and returning an order ID:***
+**_Helpful diagram highlighting the sequence of events required for a client + server integration for creating and returning an order ID:_**
 
 ```mermaid
 sequenceDiagram
@@ -135,9 +135,9 @@ onApprove(data, actions) {
 
 ## New state of client + server integration behavior
 
-You will need to replace the client-side code to call your server instead.  Your server must implment `capture` or `authorize` REST calls as appropriate depending on your use case.
+You will need to replace the client-side code to call your server instead. Your server must implment `capture` or `authorize` REST calls as appropriate depending on your use case.
 
-NOTE:  Weith a client-side only integration, the `actions` helper passes order ID under the hood to capture the order.  You will now need to manually pass this order ID to your server side to process the relevant `capture` or `authorize` REST calls on your server:
+NOTE: Weith a client-side only integration, the `actions` helper passes order ID under the hood to capture the order. You will now need to manually pass this order ID to your server side to process the relevant `capture` or `authorize` REST calls on your server:
 
 ```js
 onApprove: function (data, actions) {
@@ -213,17 +213,20 @@ To securely store your credentials in your application code, we recommend using 
    Here's an example API call in Node.js that uses the client credentials auth token as the Authorization header for all other API calls:
 
 ```js
-const encodedClientCredentials = Buffer.from(`${client}:${secret}`).toString("base64");
+const encodedClientCredentials = Buffer.from(`${client}:${secret}`).toString(
+  "base64"
+);
 
 const response = await fetch(`${apiBaseUrl}/v1/oauth2/token`, {
-    method: "POST",
-    body: "grant_type=client_credentials",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-      "Accept-Language": "en_US",
-      Authorization: `Basic ${encodedClientCredentials}`,
-    }});
+  method: "POST",
+  body: "grant_type=client_credentials",
+  headers: {
+    Accept: "application/json",
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Accept-Language": "en_US",
+    Authorization: `Basic ${encodedClientCredentials}`,
+  },
+});
 
 const data = await response.json();
 

--- a/docs/update-from-client-side-helpers-to-server-side.md
+++ b/docs/update-from-client-side-helpers-to-server-side.md
@@ -212,7 +212,7 @@ To securely store your credentials in your application code, we recommend using 
 2. The client credentials auth token returned by `/v1/oauth2/token` api endpoint should never be passed to the browser. Keep this value in memory on the server-side and use it as the Authorization header for all other api calls.  
    Here's an example API call in Node.js that uses the client credentials auth token as the Authorization header for all other API calls:
 
-```
+```js
 const encodedClientCredentials = Buffer.from(`${client}:${secret}`).toString("base64");
 
 const response = await fetch(`${apiBaseUrl}/v1/oauth2/token`, {
@@ -223,7 +223,7 @@ const response = await fetch(`${apiBaseUrl}/v1/oauth2/token`, {
       "Content-Type": "application/x-www-form-urlencoded",
       "Accept-Language": "en_US",
       Authorization: `Basic ${encodedClientCredentials}`,
-    });
+    }});
 
 const data = await response.json();
 

--- a/docs/update-from-client-side-helpers-to-server-side.md
+++ b/docs/update-from-client-side-helpers-to-server-side.md
@@ -5,7 +5,7 @@ We recommend using a combination of client-side and server-side code to integrat
 
 > **Know before you code**
 >
-> [How to Setup a Developer Account](https://www.youtube.com/watch?v=O_9G722SpXQ&t=72s) > <br/><br/>
+> [How to Setup a Developer Account](https://www.youtube.com/watch?v=O_9G722SpXQ&t=72s) <br/><br/>
 
 # What do I need to change?
 

--- a/src/controller/order-controller.ts
+++ b/src/controller/order-controller.ts
@@ -4,10 +4,10 @@ import createOrder from "../order/create-order";
 import captureOrder from "../order/capture-order";
 import getOrder from "../order/get-order";
 import patchOrder from "../order/patch-order";
+import type { PatchOrderResponse, PatchRequest } from "../order/patch-order";
 import products from "../data/products.json";
 import shippingCost from "../data/shipping-cost.json";
 import config from "../config";
-import type { PatchOrderResponse, PatchRequest } from "../order/order";
 
 import type {
   CreateOrderRequestBody,

--- a/src/order/capture-order.ts
+++ b/src/order/capture-order.ts
@@ -3,48 +3,72 @@ import { randomUUID } from "crypto";
 import config from "../config";
 import getAuthToken from "../auth/get-auth-token";
 
-import type { OrderResponseBody } from "@paypal/paypal-js";
+import type {
+  OrderResponseBody,
+  OrderResponseBodyMinimal,
+} from "@paypal/paypal-js";
+import type {
+  HttpErrorResponse,
+  CHTTPStatusCodeSuccessResponse,
+  OrderErrorResponse,
+  OrderResponse,
+} from "./order";
 
 const {
   paypal: { apiBaseUrl },
 } = config;
 
-type CaptureOrderResponse = {
+type CaptureOrderRequestBody = {
   [key: string]: unknown;
-  details?: Record<string, string>;
-  name?: string;
-  message?: string;
-  debug_id?: string;
-} & OrderResponseBody;
+  payment_source?: { [key: string]: unknown };
+};
 
-type HttpErrorResponse = {
-  statusCode?: number;
-  details?: Record<string, string>;
-  debug_id?: string;
-} & Error;
+type CaptureOrderRequestHeaders = Partial<{
+  "PayPal-Auth-Assertion": string;
+  "PayPal-Client-Metadata-Id": string;
+  "PayPal-Request-Id": string;
+  Prefer: string;
+  Authorization: string;
+  "Content-Type": string;
+  prefer_header: string;
+}>;
+
+type CaptureOrderOptions = {
+  body?: CaptureOrderRequestBody;
+  headers: CaptureOrderRequestHeaders;
+  orderID: string;
+};
 
 export default async function captureOrder(
   orderID: string
-): Promise<{ data: CaptureOrderResponse; httpStatus: number }> {
-  const uniqueRequestId = randomUUID();
+): Promise<OrderResponse> {
+  const uniqueRequestId: string = randomUUID();
   // Call the API
-  let { data, httpStatus } = await captureOrderAPI(orderID, uniqueRequestId);
-
+  let responseData = await captureOrderAPI({
+    headers: {
+      "PayPal-Request-Id": uniqueRequestId,
+      Prefer: "return=representation",
+    },
+    orderID,
+  });
   // For 5xx capture errors specifically, implement optional idempotent retry https://developer.paypal.com/reference/guidelines/idempotency/
-  if (httpStatus >= 500) {
+  if ((responseData.httpStatusCode as number) >= 500) {
     // sleep 2 seconds
     await new Promise((resolve) => setTimeout(resolve, 2000));
     // retry identical request
-    ({ data, httpStatus } = await captureOrderAPI(orderID, uniqueRequestId));
+    responseData = await captureOrderAPI({
+      headers: { "PayPal-Request-Id": uniqueRequestId },
+      orderID,
+    });
   }
-
-  return { data, httpStatus };
+  return responseData;
 }
 
-async function captureOrderAPI(
-  orderID: string,
-  uniqueRequestId: string
-): Promise<{ data: CaptureOrderResponse; httpStatus: number }> {
+async function captureOrderAPI({
+  orderID,
+  body,
+  headers,
+}: CaptureOrderOptions): Promise<OrderResponse> {
   if (!orderID) {
     throw new Error("MISSING_ORDER_ID_FOR_CAPTURE_ORDER");
   }
@@ -52,28 +76,45 @@ async function captureOrderAPI(
 
   const defaultErrorMessage = "FAILED_TO_CAPTURE_ORDER";
 
+  const requestHeaders = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    // Uncomment one of these to force an error for negative testing (in sandbox mode only). Documentation:
+    // https://developer.paypal.com/tools/sandbox/negative-testing/request-headers/
+    // "PayPal-Mock-Response": '{"mock_application_codes": "INSTRUMENT_DECLINED"}'
+    // "PayPal-Mock-Response": '{"mock_application_codes": "TRANSACTION_REFUSED"}'
+    ...headers,
+  };
+
   let response;
   try {
     response = await fetch(
       `${apiBaseUrl}/v2/checkout/orders/${orderID}/capture`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-          "Accept-Language": "en_US",
-          "PayPal-Request-Id": uniqueRequestId,
-          // Uncomment one of these to force an error for negative testing (in sandbox mode only). Documentation:
-          // https://developer.paypal.com/tools/sandbox/negative-testing/request-headers/
-          // "PayPal-Mock-Response": '{"mock_application_codes": "INSTRUMENT_DECLINED"}'
-          // "PayPal-Mock-Response": '{"mock_application_codes": "TRANSACTION_REFUSED"}'
-        },
+        headers: requestHeaders,
+        body: JSON.stringify(body),
       }
     );
 
-    const data = (await response.json()) as CaptureOrderResponse;
+    const data = await response.json();
 
-    return { data, httpStatus: response.status };
+    if (response.ok) {
+      return {
+        status: "ok",
+        data:
+          requestHeaders.Prefer === "return=minimal"
+            ? (data as OrderResponseBodyMinimal)
+            : (data as OrderResponseBody),
+        httpStatusCode: response.status as CHTTPStatusCodeSuccessResponse,
+      };
+    } else {
+      return {
+        status: "error",
+        data: data as OrderErrorResponse,
+        httpStatusCode: response.status,
+      };
+    }
   } catch (error) {
     const httpError: HttpErrorResponse =
       error instanceof Error ? error : new Error(defaultErrorMessage);

--- a/src/order/capture-order.ts
+++ b/src/order/capture-order.ts
@@ -9,7 +9,7 @@ import type {
 } from "@paypal/paypal-js";
 import type {
   HttpErrorResponse,
-  CHTTPStatusCodeSuccessResponse,
+  CreateCaptureHTTPStatusCodeSuccessResponse,
   OrderErrorResponse,
   OrderResponse,
 } from "./order";
@@ -30,7 +30,6 @@ type CaptureOrderRequestHeaders = Partial<{
   Prefer: string;
   Authorization: string;
   "Content-Type": string;
-  prefer_header: string;
 }>;
 
 type CaptureOrderOptions = {
@@ -106,7 +105,8 @@ async function captureOrderAPI({
           requestHeaders.Prefer === "return=minimal"
             ? (data as OrderResponseBodyMinimal)
             : (data as OrderResponseBody),
-        httpStatusCode: response.status as CHTTPStatusCodeSuccessResponse,
+        httpStatusCode:
+          response.status as CreateCaptureHTTPStatusCodeSuccessResponse,
       };
     } else {
       return {

--- a/src/order/create-order.ts
+++ b/src/order/create-order.ts
@@ -4,7 +4,7 @@ import getAuthToken from "../auth/get-auth-token";
 
 import type {
   CreateOrderRequestBody,
-  OrderResponseBody,
+  OrderResponseBodyMinimal,
 } from "@paypal/paypal-js";
 
 const {
@@ -21,7 +21,7 @@ type CreateOrderErrorResponse = {
   debug_id: string;
 };
 
-type CreateOrderSuccessResponse = OrderResponseBody;
+type CreateOrderSuccessResponse = OrderResponseBodyMinimal;
 
 type HttpErrorResponse = {
   statusCode?: number;
@@ -60,6 +60,7 @@ export default async function createOrder(
         "Content-Type": "application/json",
         Authorization: `Bearer ${accessToken}`,
         "Accept-Language": "en_US",
+        Prefer: "return=minimal",
         "PayPal-Request-Id": SET_BUT_EMPTY, // API requires this header if payment_source.paypal.experience_context is in payload, however it's not applicable to this use case so SET_BUT_EMPTY
       },
       body: JSON.stringify(orderPayload),

--- a/src/order/create-order.ts
+++ b/src/order/create-order.ts
@@ -5,65 +5,57 @@ import getAuthToken from "../auth/get-auth-token";
 import type {
   CreateOrderRequestBody,
   OrderResponseBodyMinimal,
+  OrderResponseBody,
 } from "@paypal/paypal-js";
+import type {
+  HttpErrorResponse,
+  OrderResponse,
+  OrderErrorResponse,
+  CHTTPStatusCodeSuccessResponse,
+} from "./order";
 
 const {
   paypal: { apiBaseUrl },
 } = config;
 
-type HTTPStatusCodeSuccessResponse = 200 | 201;
+type CreateOrderRequestHeaders = Partial<{
+  "Content-Type": string;
+  Authorization: string;
+  "Accept-Language": string;
+  Prefer: string;
+  "PayPal-Request-Id": string;
+}>;
 
-type CreateOrderErrorResponse = {
-  [key: string]: unknown;
-  details: Record<string, string>;
-  name: string;
-  message: string;
-  debug_id: string;
+type CreateOrderOptions = {
+  body: CreateOrderRequestBody;
+  headers?: CreateOrderRequestHeaders;
 };
 
-type CreateOrderSuccessResponse = OrderResponseBodyMinimal;
-
-type HttpErrorResponse = {
-  statusCode?: number;
-  details?: Record<string, string>;
-} & Error;
-
-type CreateOrderResponse =
-  | {
-      status: "ok";
-      data: CreateOrderSuccessResponse;
-      httpStatusCode: HTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: CreateOrderErrorResponse;
-      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
-    };
-
-export default async function createOrder(
-  orderPayload: CreateOrderRequestBody
-): Promise<CreateOrderResponse> {
-  if (!orderPayload) {
+export default async function createOrder({
+  body,
+  headers = {},
+}: CreateOrderOptions): Promise<OrderResponse> {
+  if (!body) {
     throw new Error("MISSING_PAYLOAD_FOR_CREATE_ORDER");
   }
 
   const { access_token: accessToken } = await getAuthToken();
-
   const defaultErrorMessage = "FAILED_TO_CREATE_ORDER";
+
+  const requestHeaders = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    "Accept-Language": "en_US",
+    Prefer: "return=minimal",
+    ...headers,
+  };
 
   let response;
   try {
-    const SET_BUT_EMPTY = " "; // a single space
     response = await fetch(`${apiBaseUrl}/v2/checkout/orders`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-        "Accept-Language": "en_US",
-        Prefer: "return=minimal",
-        "PayPal-Request-Id": SET_BUT_EMPTY, // API requires this header if payment_source.paypal.experience_context is in payload, however it's not applicable to this use case so SET_BUT_EMPTY
-      },
-      body: JSON.stringify(orderPayload),
+      headers: requestHeaders,
+      body: JSON.stringify(body),
     });
 
     const data = await response.json();
@@ -71,13 +63,16 @@ export default async function createOrder(
     if (response.ok) {
       return {
         status: "ok",
-        data: data as CreateOrderSuccessResponse,
-        httpStatusCode: response.status as HTTPStatusCodeSuccessResponse,
+        data:
+          requestHeaders.Prefer === "return=minimal"
+            ? (data as OrderResponseBodyMinimal)
+            : (data as OrderResponseBody),
+        httpStatusCode: response.status as CHTTPStatusCodeSuccessResponse,
       };
     } else {
       return {
         status: "error",
-        data: data as CreateOrderErrorResponse,
+        data: data as OrderErrorResponse,
         httpStatusCode: response.status,
       };
     }

--- a/src/order/create-order.ts
+++ b/src/order/create-order.ts
@@ -11,7 +11,7 @@ import type {
   HttpErrorResponse,
   OrderResponse,
   OrderErrorResponse,
-  CHTTPStatusCodeSuccessResponse,
+  CreateCaptureHTTPStatusCodeSuccessResponse,
 } from "./order";
 
 const {
@@ -67,7 +67,8 @@ export default async function createOrder({
           requestHeaders.Prefer === "return=minimal"
             ? (data as OrderResponseBodyMinimal)
             : (data as OrderResponseBody),
-        httpStatusCode: response.status as CHTTPStatusCodeSuccessResponse,
+        httpStatusCode:
+          response.status as CreateCaptureHTTPStatusCodeSuccessResponse,
       };
     } else {
       return {

--- a/src/order/get-order.ts
+++ b/src/order/get-order.ts
@@ -3,7 +3,12 @@ import config from "../config";
 import getAuthToken from "../auth/get-auth-token";
 
 import type { OrderResponseBody } from "@paypal/paypal-js";
-import type { OrderErrorResponse, HttpErrorResponse } from "./order";
+import type {
+  OrderErrorResponse,
+  HttpErrorResponse,
+  OrderResponseSuccess,
+  OrderResponseError,
+} from "./order";
 
 const {
   paypal: { apiBaseUrl },
@@ -22,17 +27,12 @@ type GetOrderOptions = {
   query?: { fields: string };
 };
 
-type GetOrderResponse =
-  | {
-      status: "ok";
-      data: OrderResponseBody;
-      httpStatusCode: GetHTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: OrderErrorResponse;
-      httpStatusCode: Omit<number, GetHTTPStatusCodeSuccessResponse>;
-    };
+interface GetOrderResponseSuccess extends OrderResponseSuccess {
+  data: OrderResponseBody;
+  httpStatusCode: GetHTTPStatusCodeSuccessResponse;
+}
+
+type GetOrderResponse = GetOrderResponseSuccess | OrderResponseError;
 
 export default async function getOrder({
   orderID,

--- a/src/order/get-order.ts
+++ b/src/order/get-order.ts
@@ -3,16 +3,13 @@ import config from "../config";
 import getAuthToken from "../auth/get-auth-token";
 
 import type { OrderResponseBody } from "@paypal/paypal-js";
-import type {
-  OrderErrorResponse,
-  GetHTTPStatusCodeSuccessResponse,
-  GetOrderResponse,
-  HttpErrorResponse,
-} from "./order";
+import type { OrderErrorResponse, HttpErrorResponse } from "./order";
 
 const {
   paypal: { apiBaseUrl },
 } = config;
+
+type GetHTTPStatusCodeSuccessResponse = 200;
 
 type GetOrderRequestHeaders = {
   Authorization: string;
@@ -24,6 +21,18 @@ type GetOrderOptions = {
   headers?: GetOrderRequestHeaders;
   query?: { fields: string };
 };
+
+type GetOrderResponse =
+  | {
+      status: "ok";
+      data: OrderResponseBody;
+      httpStatusCode: GetHTTPStatusCodeSuccessResponse;
+    }
+  | {
+      status: "error";
+      data: OrderErrorResponse;
+      httpStatusCode: Omit<number, GetHTTPStatusCodeSuccessResponse>;
+    };
 
 export default async function getOrder({
   orderID,

--- a/src/order/get-order.ts
+++ b/src/order/get-order.ts
@@ -37,7 +37,6 @@ type GetOrderResponse =
 export default async function getOrder({
   orderID,
   headers,
-  query,
 }: GetOrderOptions): Promise<GetOrderResponse> {
   if (!orderID) {
     throw new Error("MISSING_ORDER_ID");

--- a/src/order/order.d.ts
+++ b/src/order/order.d.ts
@@ -14,10 +14,6 @@ export type OrderErrorResponse = {
 
 type HTTPStatusCodeSuccessResponse = 200 | 201 | 204 | 207;
 
-export type GetHTTPStatusCodeSuccessResponse = 200;
-
-export type PatchHTTPStatusCodeSuccessResponse = 204;
-
 // for create order and capture order
 export type CHTTPStatusCodeSuccessResponse = 200 | 201;
 
@@ -51,41 +47,6 @@ export type OrderResponse =
       httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
     };
 
-export type PatchOrderResponse =
-  | {
-      status: "ok";
-      data: null;
-      httpStatusCode: PatchHTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: OrderErrorResponse;
-      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
-    };
-
-export type GetOrderResponse =
-  | {
-      status: "ok";
-      data: OrderResponseBody;
-      httpStatusCode: GetHTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: OrderErrorResponse;
-      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
-    };
-
 export type HttpErrorResponse = {
   statusCode?: number;
 } & Error;
-
-export type PatchOrderRequestBody = {
-  patch_request: PatchRequest[];
-};
-
-export type PatchRequest = {
-  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
-  from?: string;
-  path: string;
-  value: number | string | boolean | null | object;
-};

--- a/src/order/order.d.ts
+++ b/src/order/order.d.ts
@@ -14,7 +14,7 @@ export type OrderErrorResponse = {
 type HTTPStatusCodeSuccessResponse = 200 | 201 | 204 | 207;
 
 // for create order and capture order
-export type CHTTPStatusCodeSuccessResponse = 200 | 201;
+export type CreateCaptureHTTPStatusCodeSuccessResponse = 200 | 201;
 
 export type OrderRequestHeaders = Partial<{
   "Content-Type": string;
@@ -24,27 +24,24 @@ export type OrderRequestHeaders = Partial<{
   "PayPal-Request-Id": string;
 }>;
 
-type OrderResponseTypes =
-  | OrderResponseBodyMinimal
-  | OrderResponseBody
-  | OrderErrorResponse
-  | null;
-export type OrderSuccessResponseTypes =
-  | OrderResponseBodyMinimal
-  | OrderResponseBody
-  | null;
+export interface OrderResponseSuccess {
+  status: "ok";
+}
+
+interface CreateCaptureOrderResponseSuccess extends OrderResponseSuccess {
+  data: OrderResponseBodyMinimal | OrderResponseBody;
+  httpStatusCode: CreateCaptureHTTPStatusCodeSuccessResponse;
+}
+
+export type OrderResponseError = {
+  status: "error";
+  data: OrderErrorResponse;
+  httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
+};
 
 export type OrderResponse =
-  | {
-      status: "ok";
-      data: OrderResponseBodyMinimal | OrderResponseBody;
-      httpStatusCode: CHTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: OrderErrorResponse;
-      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
-    };
+  | CreateCaptureOrderResponseSuccess
+  | OrderResponseError;
 
 export type HttpErrorResponse = {
   statusCode?: number;

--- a/src/order/order.d.ts
+++ b/src/order/order.d.ts
@@ -1,0 +1,91 @@
+import type {
+  CreateOrderRequestBody,
+  OrderResponseBodyMinimal,
+  OrderResponseBody,
+} from "@paypal/paypal-js";
+
+export type OrderErrorResponse = {
+  [key: string]: unknown;
+  details: Record<string, string>;
+  name: string;
+  message: string;
+  debug_id: string;
+};
+
+type HTTPStatusCodeSuccessResponse = 200 | 201 | 204 | 207;
+
+export type GetHTTPStatusCodeSuccessResponse = 200;
+
+export type PatchHTTPStatusCodeSuccessResponse = 204;
+
+// for create order and capture order
+export type CHTTPStatusCodeSuccessResponse = 200 | 201;
+
+export type OrderRequestHeaders = Partial<{
+  "Content-Type": string;
+  Authorization: string;
+  "Accept-Language": string;
+  Prefer: string;
+  "PayPal-Request-Id": string;
+}>;
+
+type OrderResponseTypes =
+  | OrderResponseBodyMinimal
+  | OrderResponseBody
+  | OrderErrorResponse
+  | null;
+export type OrderSuccessResponseTypes =
+  | OrderResponseBodyMinimal
+  | OrderResponseBody
+  | null;
+
+export type OrderResponse =
+  | {
+      status: "ok";
+      data: OrderResponseBodyMinimal | OrderResponseBody;
+      httpStatusCode: CHTTPStatusCodeSuccessResponse;
+    }
+  | {
+      status: "error";
+      data: OrderErrorResponse;
+      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
+    };
+
+export type PatchOrderResponse =
+  | {
+      status: "ok";
+      data: null;
+      httpStatusCode: PatchHTTPStatusCodeSuccessResponse;
+    }
+  | {
+      status: "error";
+      data: OrderErrorResponse;
+      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
+    };
+
+export type GetOrderResponse =
+  | {
+      status: "ok";
+      data: OrderResponseBody;
+      httpStatusCode: GetHTTPStatusCodeSuccessResponse;
+    }
+  | {
+      status: "error";
+      data: OrderErrorResponse;
+      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
+    };
+
+export type HttpErrorResponse = {
+  statusCode?: number;
+} & Error;
+
+export type PatchOrderRequestBody = {
+  patch_request: PatchRequest[];
+};
+
+export type PatchRequest = {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
+  from?: string;
+  path: string;
+  value: number | string | boolean | null | object;
+};

--- a/src/order/order.d.ts
+++ b/src/order/order.d.ts
@@ -1,5 +1,4 @@
 import type {
-  CreateOrderRequestBody,
   OrderResponseBodyMinimal,
   OrderResponseBody,
 } from "@paypal/paypal-js";

--- a/src/order/patch-order.ts
+++ b/src/order/patch-order.ts
@@ -1,17 +1,13 @@
 import { fetch } from "undici";
 import config from "../config";
 import getAuthToken from "../auth/get-auth-token";
-import type {
-  OrderErrorResponse,
-  PatchOrderResponse,
-  PatchHTTPStatusCodeSuccessResponse,
-  HttpErrorResponse,
-  PatchOrderRequestBody,
-} from "./order";
+import type { OrderErrorResponse, HttpErrorResponse } from "./order";
 
 const {
   paypal: { apiBaseUrl },
 } = config;
+
+type PatchHTTPStatusCodeSuccessResponse = 204;
 
 type PatchOrderRequestHeaders = {
   "Content-Type": string;
@@ -23,6 +19,29 @@ type PatchOrderOptions = {
   headers?: PatchOrderRequestHeaders;
   orderID: string;
 };
+
+export type PatchRequest = {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
+  from?: string;
+  path: string;
+  value: number | string | boolean | null | object;
+};
+
+type PatchOrderRequestBody = {
+  patch_request: PatchRequest[];
+};
+
+export type PatchOrderResponse =
+  | {
+      status: "ok";
+      data: null;
+      httpStatusCode: PatchHTTPStatusCodeSuccessResponse;
+    }
+  | {
+      status: "error";
+      data: OrderErrorResponse;
+      httpStatusCode: Omit<number, PatchHTTPStatusCodeSuccessResponse>;
+    };
 
 export default async function patchOrder({
   orderID,

--- a/src/order/patch-order.ts
+++ b/src/order/patch-order.ts
@@ -1,42 +1,34 @@
 import { fetch } from "undici";
 import config from "../config";
 import getAuthToken from "../auth/get-auth-token";
+import type {
+  OrderErrorResponse,
+  PatchOrderResponse,
+  PatchHTTPStatusCodeSuccessResponse,
+  HttpErrorResponse,
+  PatchOrderRequestBody,
+} from "./order";
 
 const {
   paypal: { apiBaseUrl },
 } = config;
 
-type HTTPStatusCodeSuccessResponse = 204;
-
-type PatchOrderErrorResponse = {
-  [key: string]: unknown;
-  details: Record<string, string>;
-  name: string;
-  message: string;
-  debug_id: string;
+type PatchOrderRequestHeaders = {
+  "Content-Type": string;
+  Authorization: string;
 };
 
-type HttpErrorResponse = {
-  statusCode?: number;
-  details?: Record<string, string>;
-} & Error;
+type PatchOrderOptions = {
+  body: PatchOrderRequestBody;
+  headers?: PatchOrderRequestHeaders;
+  orderID: string;
+};
 
-export type PatchOrderResponse =
-  | {
-      status: "ok";
-      data: null;
-      httpStatusCode: HTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: PatchOrderErrorResponse;
-      httpStatusCode: Omit<number, HTTPStatusCodeSuccessResponse>;
-    };
-
-export default async function patchOrder(
-  orderID: string,
-  patchPayload: any
-): Promise<PatchOrderResponse> {
+export default async function patchOrder({
+  orderID,
+  headers,
+  body,
+}: PatchOrderOptions): Promise<PatchOrderResponse> {
   if (!orderID) {
     throw new Error("MISSING_ORDER_ID_FOR_PATCH_ORDER");
   }
@@ -45,16 +37,18 @@ export default async function patchOrder(
 
   const defaultErrorMessage = "FAILED_TO_PATCH_ORDER";
 
+  const requestHeaders = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    ...headers,
+  };
+
   let response;
   try {
     response = await fetch(`${apiBaseUrl}/v2/checkout/orders/${orderID}`, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${accessToken}`,
-        "Accept-Language": "en_US",
-      },
-      body: JSON.stringify(patchPayload),
+      headers: requestHeaders,
+      body: JSON.stringify(body.patch_request),
     });
 
     if (response.status === 204) {
@@ -62,14 +56,14 @@ export default async function patchOrder(
       return {
         status: "ok",
         data: null,
-        httpStatusCode: response.status as HTTPStatusCodeSuccessResponse,
+        httpStatusCode: response.status as PatchHTTPStatusCodeSuccessResponse,
       };
     } else {
       const data = await response.json();
 
       return {
         status: "error",
-        data: data as PatchOrderErrorResponse,
+        data: data as OrderErrorResponse,
         httpStatusCode: response.status,
       };
     }

--- a/src/order/patch-order.ts
+++ b/src/order/patch-order.ts
@@ -1,7 +1,12 @@
 import { fetch } from "undici";
 import config from "../config";
 import getAuthToken from "../auth/get-auth-token";
-import type { OrderErrorResponse, HttpErrorResponse } from "./order";
+import type {
+  OrderErrorResponse,
+  HttpErrorResponse,
+  OrderResponseError,
+  OrderResponseSuccess,
+} from "./order";
 
 const {
   paypal: { apiBaseUrl },
@@ -30,18 +35,12 @@ export type PatchRequest = {
 type PatchOrderRequestBody = {
   patch_request: PatchRequest[];
 };
+interface PatchOrderResponseSuccess extends OrderResponseSuccess {
+  data: null;
+  httpStatusCode: PatchHTTPStatusCodeSuccessResponse;
+}
 
-export type PatchOrderResponse =
-  | {
-      status: "ok";
-      data: null;
-      httpStatusCode: PatchHTTPStatusCodeSuccessResponse;
-    }
-  | {
-      status: "error";
-      data: OrderErrorResponse;
-      httpStatusCode: Omit<number, PatchHTTPStatusCodeSuccessResponse>;
-    };
+export type PatchOrderResponse = PatchOrderResponseSuccess | OrderResponseError;
 
 export default async function patchOrder({
   orderID,


### PR DESCRIPTION
pass custom headers to order API calls: 

1. createOrder
2. captureOrder
3. getOrder
4. patchOrder

before:
`async function patchOrder(
  orderID
): Promise<PatchOrderResponse> `

after:
`async function patchOrder({
  orderID,
  headers,
  body,
}: PatchOrderOptions): Promise<PatchOrderResponse> `