### PR TITLE
chore: update hosted-fields to use orderID naming convention

### DIFF
--- a/public/hosted-fields.html
+++ b/public/hosted-fields.html
@@ -177,7 +177,7 @@
                       hostedFieldsOrderData,
                     });
 
-                    return onApprove(hostedFieldsOrderData.orderId);
+                    return onApprove(hostedFieldsOrderData.orderID);
                   })
                   .catch((error) => {
                     console.error("failed to submit payment", error);


### PR DESCRIPTION
Update the hosted-fields example to prefer `orderID` instead of `orderId`. This way it matches the Buttons example integration code.