### PR TITLE
Listen to PORT env var for heroku deployments

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import buildApp from "./app";
 
-const FASTIFY_PORT = Number(process.env.FASTIFY_PORT) || 3006;
+const FASTIFY_PORT =
+  Number(process.env.PORT) || Number(process.env.FASTIFY_PORT) || 3006;
 const FASTIFY_HOST = process.env.FASTIFY_HOST || "localhost";
 
 const envToLogger = {


### PR DESCRIPTION
* Listen to `PORT` environment variable as well for deployment to heroku. 